### PR TITLE
Cred Object Description

### DIFF
--- a/active-email.ps1
+++ b/active-email.ps1
@@ -1,9 +1,9 @@
 $emailFromAddress = "xxx@xxx.com"
 $bccemail = "xxx@xxx.com"
 $emailToAddress = "xxx@xxx.com"
-$emailSMTPServer = "outlook.office365.com"
+$emailSMTPServer = "SMTP SERVER ADDRESS"
 $emailSubject = "User List"
-$emailBodyText = "#AUTOMATED EMAIL# - Attached User List for - " 
+$emailBodyText = "#AUTOMATED EMAIL# - Attached User List for - XXXX" 
 $date = Get-Date -format d-M-yyyy
 $emailBody = $emailBodyText + $date
 $credObject = Get-AutomationPSCredential -Name 'automation'


### PR DESCRIPTION
This script only works in Microsoft Azure using the Credetial Object. The 'automation' variable in the script is created in MS Azure and it obscures username and password fields out of the script.